### PR TITLE
PS tabbing fix using additional dom attribute

### DIFF
--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -2137,10 +2137,10 @@ describe('Grid', () => {
       );
       expect(
         grid.state.instanceProps.columnSizeAndPositionManager.getTotalSize(),
-      ).toEqual(1500);
+      ).toEqual(1450);
       expect(
         grid.state.instanceProps.rowSizeAndPositionManager.getTotalSize(),
-      ).toEqual(150);
+      ).toEqual(155);
       grid.measureAllCells();
       expect(
         grid.state.instanceProps.columnSizeAndPositionManager.getTotalSize(),

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1345,11 +1345,11 @@ describe('Grid', () => {
           scrollToRow: 50,
         }),
       );
-      expect(helper.columnOverscanStartIndex()).toEqual(19);
+      expect(helper.columnOverscanStartIndex()).toEqual(21);
       expect(helper.columnOverscanStopIndex()).toEqual(27);
       expect(helper.columnStartIndex()).toEqual(21);
       expect(helper.columnStopIndex()).toEqual(25);
-      expect(helper.rowOverscanStartIndex()).toEqual(40);
+      expect(helper.rowOverscanStartIndex()).toEqual(45);
       expect(helper.rowOverscanStopIndex()).toEqual(55);
       expect(helper.rowStartIndex()).toEqual(45);
       expect(helper.rowStopIndex()).toEqual(50);
@@ -1558,11 +1558,11 @@ describe('Grid', () => {
       await onSectionRenderedPromise;
 
       // It should overscan in the direction being scrolled while scroll is in progress
-      expect(helper.columnOverscanStartIndex()).toEqual(1);
+      expect(helper.columnOverscanStartIndex()).toEqual(3);
       expect(helper.columnOverscanStopIndex()).toEqual(9);
       expect(helper.columnStartIndex()).toEqual(3);
       expect(helper.columnStopIndex()).toEqual(7);
-      expect(helper.rowOverscanStartIndex()).toEqual(4);
+      expect(helper.rowOverscanStartIndex()).toEqual(9);
       expect(helper.rowOverscanStopIndex()).toEqual(19);
       expect(helper.rowStartIndex()).toEqual(9);
       expect(helper.rowStopIndex()).toEqual(14);
@@ -1582,11 +1582,11 @@ describe('Grid', () => {
 
       // It reset overscan once scrolling has finished
       expect(helper.columnOverscanStartIndex()).toEqual(0);
-      expect(helper.columnOverscanStopIndex()).toEqual(7);
+      expect(helper.columnOverscanStopIndex()).toEqual(5);
       expect(helper.columnStartIndex()).toEqual(1);
       expect(helper.columnStopIndex()).toEqual(5);
       expect(helper.rowOverscanStartIndex()).toEqual(0);
-      expect(helper.rowOverscanStopIndex()).toEqual(14);
+      expect(helper.rowOverscanStopIndex()).toEqual(9);
       expect(helper.rowStartIndex()).toEqual(4);
       expect(helper.rowStopIndex()).toEqual(9);
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -1149,9 +1149,6 @@ class Grid extends React.PureComponent<Props, State> {
 
       // Adjust rows/columns count for max values within visible area
       this.adjustForOverlapping(visibleColumnIndices, visibleRowIndices);
-      console.log(
-        'Rows: ' + (visibleRowIndices.stop - visibleRowIndices.start),
-      );
 
       const horizontalOffsetAdjustment = instanceProps.columnSizeAndPositionManager.getOffsetAdjustment(
         {

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -1005,17 +1005,22 @@ class Grid extends React.PureComponent<Props, State> {
       this._resetStyleCache();
     }
 
-    // Reset max visible rows count when height changes
-    if (this.state.instanceProps.prevHeight !== this.props.height) {
-      this._maxRenderedRowCount = 0;
-      this.state.instanceProps.prevHeight = this.props.height;
-    }
-
-    // Reset max visible columns count when width changes
-    if (this.state.instanceProps.prevWidth !== this.props.width) {
-      this._maxRenderedColumnCount = 0;
-      this.state.instanceProps.prevWidth = this.props.width;
-    }
+    let visibleColumnIndices = instanceProps.columnSizeAndPositionManager.getVisibleCellRange(
+      {
+        containerSize: width,
+        offset: 0,
+      },
+    );
+    this._maxRenderedColumnCount =
+      visibleColumnIndices.stop - visibleColumnIndices.start + 1;
+    let visibleRowIndices = instanceProps.rowSizeAndPositionManager.getVisibleCellRange(
+      {
+        containerSize: height,
+        offset: 0,
+      },
+    );
+    this._maxRenderedRowCount =
+      visibleRowIndices.stop - visibleRowIndices.start + 1;
 
     // calculate children to render here
     this._calculateChildrenToRender(this.props, this.state);
@@ -1144,6 +1149,9 @@ class Grid extends React.PureComponent<Props, State> {
 
       // Adjust rows/columns count for max values within visible area
       this.adjustForOverlapping(visibleColumnIndices, visibleRowIndices);
+      console.log(
+        'Rows: ' + (visibleRowIndices.stop - visibleRowIndices.start),
+      );
 
       const horizontalOffsetAdjustment = instanceProps.columnSizeAndPositionManager.getOffsetAdjustment(
         {
@@ -1271,11 +1279,6 @@ class Grid extends React.PureComponent<Props, State> {
   }
 
   adjustForOverlapping(visibleColumnIndices, visibleRowIndices) {
-    // Max columns within visible area is always plus 1 (Overlapping)
-    if (this._maxRenderedColumnCount == 0) {
-      this._maxRenderedColumnCount =
-        visibleColumnIndices.stop - visibleColumnIndices.start + 1;
-    }
     if (
       this._maxRenderedColumnCount !=
       visibleColumnIndices.stop - visibleColumnIndices.start
@@ -1283,11 +1286,7 @@ class Grid extends React.PureComponent<Props, State> {
       if (visibleColumnIndices.start > 0) visibleColumnIndices.start--;
       else visibleColumnIndices.stop++;
     }
-    // Max rows within visible area is always plus 1 (Overlapping)
-    if (this._maxRenderedRowCount == 0) {
-      this._maxRenderedRowCount =
-        visibleRowIndices.stop - visibleRowIndices.start + 1;
-    }
+
     if (
       this._maxRenderedRowCount !=
       visibleRowIndices.stop - visibleRowIndices.start

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -21,17 +21,6 @@ function foreachKey(
   }
 }
 
-// function checkValuesUnique(values) {
-//   let newSet = new Set();
-//   for (let value of values) {
-//     if (newSet.has(value)) {
-//       debugger;
-//     } else {
-//       newSet.add(value);
-//     }
-//   }
-// }
-
 class ReusableKeyCache {
   constructor() {
     this.lastMap = new Map();
@@ -136,7 +125,6 @@ export default function defaultCellRangeRenderer({
     columnStartIndex,
     columnStopIndex,
   );
-  //  console.log('+++++++', JSON.stringify(Array.from(reusableKeyMap.values())));
 
   // Browsers have native size limits for elements (eg Chrome 33M pixels, IE 1.5M pixes).
   // User cannot scroll beyond these size limitations.
@@ -257,10 +245,8 @@ export default function defaultCellRangeRenderer({
     }
   }
 
-  // checkValuesUnique(renderedCells.map(cell => cell.key));
-
   renderedCells.sort((a, b) => {
-    return parseInt(b.key) - parseInt(a.key);
+    return parseInt(a.key) - parseInt(b.key);
   });
 
   return renderedCells;

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -136,6 +136,7 @@ export default function defaultCellRangeRenderer({
     rowSizeAndPositionManager.areOffsetsAdjusted();
 
   const canCacheStyle = !isScrolling && !areOffsetsAdjusted;
+  let dataOrder = 0;
 
   for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
     let rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(rowIndex);
@@ -198,6 +199,7 @@ export default function defaultCellRangeRenderer({
         parent,
         rowIndex,
         style,
+        dataOrder: dataOrder++,
       };
 
       let renderedCell;

--- a/source/Grid/defaultOverscanIndicesGetter.js
+++ b/source/Grid/defaultOverscanIndicesGetter.js
@@ -20,9 +20,18 @@ export default function defaultOverscanIndicesGetter({
   startIndex,
   stopIndex,
 }: OverscanIndicesGetterParams): OverscanIndices {
-  // TODO: Move to application. Making buffer cells in both directions
-  return {
-    overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
-    overscanStopIndex: Math.min(cellCount - 1, stopIndex + overscanCellsCount),
-  };
+  if (scrollDirection === SCROLL_DIRECTION_FORWARD) {
+    return {
+      overscanStartIndex: Math.max(0, startIndex),
+      overscanStopIndex: Math.min(
+        cellCount - 1,
+        stopIndex + overscanCellsCount,
+      ),
+    };
+  } else {
+    return {
+      overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
+      overscanStopIndex: Math.min(cellCount - 1, stopIndex),
+    };
+  }
 }

--- a/source/InfiniteLoader/InfiniteLoader.jest.js
+++ b/source/InfiniteLoader/InfiniteLoader.jest.js
@@ -91,6 +91,7 @@ describe('InfiniteLoader', () => {
       12,
       13,
       14,
+      15,
     ]);
   });
 
@@ -101,7 +102,7 @@ describe('InfiniteLoader', () => {
 
   it('should call :loadMoreRows for unloaded rows within the threshold', () => {
     render(getMarkup());
-    expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 14}]);
+    expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 15}]);
   });
 
   it('should call :loadMoreRows for unloaded rows within the rowCount', () => {
@@ -180,7 +181,7 @@ describe('InfiniteLoader', () => {
         }),
       );
       expect(loadMoreRowsCalls.length).toEqual(1);
-      expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 14}]);
+      expect(loadMoreRowsCalls).toEqual([{startIndex: 0, stopIndex: 15}]);
     });
 
     it('should respect the specified :minimumBatchSize if a user scrolls past the previous range', () => {

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -215,6 +215,7 @@ export default class List extends React.PureComponent<Props> {
     isScrolling,
     isVisible,
     key,
+    dataOrder,
   }: CellRendererParams) => {
     const {rowRenderer} = this.props;
 
@@ -237,6 +238,7 @@ export default class List extends React.PureComponent<Props> {
       isVisible,
       key,
       parent,
+      dataOrder,
     });
   };
 


### PR DESCRIPTION
* Added new cell parameter `dataOrder` to represent visual order of elements.
* Clients are required to set this to `data-order` attribute of cell to allow `react-spectrum` to tab elements correctly.
* Also refactored the logic to keep the row count constant.
