### PR TITLE
`dataOrder` attribute now handles over scan rows and columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Just follow these steps
 - run ```yarn remove react-virtualized```
 - run ```yarn add @adobe/react-virtualized```
 - change your require("react-virtualized") expressions to require("@adobe/react-virtualized")
-- make sure you use the "key" parameter provided to your rowRenderer function for each row
-- because of dom recycling cell components are mounted only once so clean cells in `componentWillUpdate` and/or `componentDidUpdate` before resuing them.
-- dom recycling also results in different the visual order & dom order but you can use "dataOrder" parameter to set as a custom attribute on cells and use it to reterieve the visual order
+- make sure you use the`key` parameter provided to your rowRenderer/cellRenderer function for each row/cell
+- because of dom recycling cell components are mounted only once so clean cells in `componentWillUpdate` and/or `componentDidUpdate` before resuing them
+- dom recycling also results in different visual & dom order but you can use `dataOrder` parameter to set as a custom attribute on cells and use it to reterieve the visual order
 
 ## Changes
 
@@ -28,6 +28,6 @@ We fixed the problem by treating negative scroll values the same as zero when re
 
 ### Performance optimization to reuse row elements
 
-This changes the key generating algorithm to reuse keys in a rotating fashion in order to minimize expensive createElement calls when new rows come into the viewport. It also keeps the rows in the same initial document order to avoid unnecessary reordering of elements.
+This changes the key generating algorithm to reuse keys in a rotating fashion in order to minimize expensive createElement calls when new rows come into the viewport.
 
 NOTE: Reusing elements will cause transient state like focus or input field values not controlled by react state to persist and appear in different rows. If your rows contain focusable input fields then you will want to use your own key values for each list item instead of the rotating keys provided by this fork.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Just follow these steps
 - run ```yarn add @adobe/react-virtualized```
 - change your require("react-virtualized") expressions to require("@adobe/react-virtualized")
 - make sure you use the "key" parameter provided to your rowRenderer function for each row
+- because of dom recycling cell components are mounted only once so clean cells in `componentWillUpdate` and/or `componentDidUpdate` before resuing them.
+- dom recycling also results in different the visual order & dom order but you can use "dataOrder" parameter to set as a custom attribute on cells and use it to reterieve the visual order
 
 ## Changes
 

--- a/source/Grid/Grid.jest.js
+++ b/source/Grid/Grid.jest.js
@@ -1345,11 +1345,11 @@ describe('Grid', () => {
           scrollToRow: 50,
         }),
       );
-      expect(helper.columnOverscanStartIndex()).toEqual(21);
+      expect(helper.columnOverscanStartIndex()).toEqual(19);
       expect(helper.columnOverscanStopIndex()).toEqual(27);
       expect(helper.columnStartIndex()).toEqual(21);
       expect(helper.columnStopIndex()).toEqual(25);
-      expect(helper.rowOverscanStartIndex()).toEqual(45);
+      expect(helper.rowOverscanStartIndex()).toEqual(40);
       expect(helper.rowOverscanStopIndex()).toEqual(55);
       expect(helper.rowStartIndex()).toEqual(45);
       expect(helper.rowStopIndex()).toEqual(50);
@@ -1558,11 +1558,11 @@ describe('Grid', () => {
       await onSectionRenderedPromise;
 
       // It should overscan in the direction being scrolled while scroll is in progress
-      expect(helper.columnOverscanStartIndex()).toEqual(3);
+      expect(helper.columnOverscanStartIndex()).toEqual(1);
       expect(helper.columnOverscanStopIndex()).toEqual(9);
       expect(helper.columnStartIndex()).toEqual(3);
       expect(helper.columnStopIndex()).toEqual(7);
-      expect(helper.rowOverscanStartIndex()).toEqual(9);
+      expect(helper.rowOverscanStartIndex()).toEqual(4);
       expect(helper.rowOverscanStopIndex()).toEqual(19);
       expect(helper.rowStartIndex()).toEqual(9);
       expect(helper.rowStopIndex()).toEqual(14);
@@ -1582,11 +1582,11 @@ describe('Grid', () => {
 
       // It reset overscan once scrolling has finished
       expect(helper.columnOverscanStartIndex()).toEqual(0);
-      expect(helper.columnOverscanStopIndex()).toEqual(5);
+      expect(helper.columnOverscanStopIndex()).toEqual(7);
       expect(helper.columnStartIndex()).toEqual(1);
       expect(helper.columnStopIndex()).toEqual(5);
       expect(helper.rowOverscanStartIndex()).toEqual(0);
-      expect(helper.rowOverscanStopIndex()).toEqual(9);
+      expect(helper.rowOverscanStopIndex()).toEqual(14);
       expect(helper.rowStartIndex()).toEqual(4);
       expect(helper.rowStopIndex()).toEqual(9);
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -1244,6 +1244,14 @@ class Grid extends React.PureComponent<Props, State> {
         }
       }
 
+      const overscanRows =
+        rowStartIndex == 0 ? 0 : rowStartIndex - this._renderedRowStartIndex;
+      const overScanCols =
+        columnStartIndex == 0
+          ? columnStopIndex + 1
+          : columnStopIndex - columnStartIndex;
+      const overscanCellCount = overscanRows * overScanCols;
+
       this._childrenToDisplay = cellRangeRenderer({
         cellCache: this._cellCache,
         cellRenderer,
@@ -1265,6 +1273,7 @@ class Grid extends React.PureComponent<Props, State> {
         verticalOffsetAdjustment,
         visibleColumnIndices,
         visibleRowIndices,
+        overscanCellCount: overscanCellCount,
       });
 
       // update the indices

--- a/source/Grid/defaultCellRangeRenderer.js
+++ b/source/Grid/defaultCellRangeRenderer.js
@@ -115,6 +115,7 @@ export default function defaultCellRangeRenderer({
   verticalOffsetAdjustment,
   visibleColumnIndices,
   visibleRowIndices,
+  overscanCellCount,
 }: CellRangeRendererParams) {
   const renderedCells = [];
 
@@ -136,7 +137,7 @@ export default function defaultCellRangeRenderer({
     rowSizeAndPositionManager.areOffsetsAdjusted();
 
   const canCacheStyle = !isScrolling && !areOffsetsAdjusted;
-  let dataOrder = 0;
+  let dataOrder = overscanCellCount;
 
   for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
     let rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(rowIndex);

--- a/source/Grid/defaultOverscanIndicesGetter.js
+++ b/source/Grid/defaultOverscanIndicesGetter.js
@@ -20,18 +20,9 @@ export default function defaultOverscanIndicesGetter({
   startIndex,
   stopIndex,
 }: OverscanIndicesGetterParams): OverscanIndices {
-  if (scrollDirection === SCROLL_DIRECTION_FORWARD) {
-    return {
-      overscanStartIndex: Math.max(0, startIndex),
-      overscanStopIndex: Math.min(
-        cellCount - 1,
-        stopIndex + overscanCellsCount,
-      ),
-    };
-  } else {
-    return {
-      overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
-      overscanStopIndex: Math.min(cellCount - 1, stopIndex),
-    };
-  }
+  // Making buffer cells in both directions
+  return {
+    overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
+    overscanStopIndex: Math.min(cellCount - 1, stopIndex + overscanCellsCount),
+  };
 }

--- a/source/List/List.jest.js
+++ b/source/List/List.jest.js
@@ -428,7 +428,7 @@ describe('List', () => {
       );
       expect(
         rendered.Grid.state.instanceProps.rowSizeAndPositionManager.getTotalSize(),
-      ).toEqual(150);
+      ).toEqual(155);
       rendered.measureAllRows();
       expect(
         rendered.Grid.state.instanceProps.rowSizeAndPositionManager.getTotalSize(),
@@ -521,7 +521,7 @@ describe('List', () => {
       ),
     );
     expect(rowRendererCalls[0].isVisible).toEqual(true);
-    expect(rowRendererCalls[1].isVisible).toEqual(false);
+    expect(rowRendererCalls[1].isVisible).toEqual(true);
   });
 
   it('should relay the Grid :parent param to the :rowRenderer', () => {


### PR DESCRIPTION
* We had added `dataOrder` attribute in ARVS to provide visual order of elements as the DOM order was changed because of DOM reuse.
* The same property was also used to determine first item in the list/grid. This PR also takes into account the buffer rows and columns that may be used.
* Made default buffer bidirectional as `dataOrder` can take care of focus.

@krisnye 

